### PR TITLE
Updated Prussian Empire to include Havel and Adler

### DIFF
--- a/Prussian_Empire.cat
+++ b/Prussian_Empire.cat
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="21449234-f135-caeb-dc80-967b0a665d4c" revision="9" gameSystemId="dea5da1e-8b51-b068-a829-a7b0a88b17d4" gameSystemRevision="1" battleScribeVersion="1.15" name="Prussian Empire" authorName="Josiah McMillan" authorContact="battlescribe@omts.org.nz" authorUrl="http://www.omts.org.nz">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="21449234-f135-caeb-dc80-967b0a665d4c" revision="10" gameSystemId="dea5da1e-8b51-b068-a829-a7b0a88b17d4" gameSystemRevision="1" battleScribeVersion="1.15" name="Prussian Empire" authorName="Josiah McMillan" authorContact="battlescribe@omts.org.nz" authorUrl="http://www.omts.org.nz" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries>
     <entry id="f2e58b90-2459-100e-798b-026a5dc1279c" name="A6-V Class Medium Tank" points="0.0" categoryId="25737efc-adbc-dc3c-7248-99ee6d9a6e72" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
@@ -66,6 +67,127 @@
           <modifiers/>
         </link>
       </links>
+    </entry>
+    <entry id="ca69-7fdc-27a5-d0c2" name="Adler Heavy Bomber" points="110.0" categoryId="25737efc-adbc-dc3c-7248-99ee6d9a6e72" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="7be0-fc0e-6cde-4b16" name="Adler" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="91d6-4971-a50e-da44" name="Momentum" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="a599-09e7-4dec-e922" name="Internal Tesla (8&quot;)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="20a5-3bda-4c34-fd83" name="Specialised Defenses (2)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="802c-9d3e-22bf-9b17" name="Rugged Construction (2)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="79f5-b557-fedb-05a1" name="Area Bombardment (Speerschleuder Bombs)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="3e9e-c325-4328-b078" name="Combat Patrol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="a172-e0ca-918d-d1c8" name="Hunter (Surface, Speerschleuder Bombs, +1)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="1267-ad22-a693-d1b9" profileTypeId="bc0a2ff0-f138-cfc5-dd1e-edb498265efb" name="Adler" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="74e0740c-a580-19f9-4d3d-a49ebaa0ef97" name="DR" value="5"/>
+                <characteristic characteristicId="6cecf2d1-c38b-7c32-980f-928bfcfd72dd" name="CR" value="7"/>
+                <characteristic characteristicId="42e40079-b4ea-86b3-13c3-781234be5776" name="MV" value="8&quot; (4&quot; min)"/>
+                <characteristic characteristicId="b7ed9b8e-0f0f-58e5-fcf4-0a6bdc956889" name="HP" value="6"/>
+                <characteristic characteristicId="d6b8e359-4e9e-c9e0-383b-36965f458d1c" name="AP" value="5"/>
+                <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="6"/>
+                <characteristic characteristicId="6007a7be-354f-4f15-7571-114f4a501d2d" name="CC" value="6"/>
+                <characteristic characteristicId="c5fbe310-6d37-3ab2-33cc-5f248f3051df" name="IR" value="4"/>
+                <characteristic characteristicId="abd884ba-477b-2dff-74c2-6a907e019bdb" name="Class" value="Medium Aerial"/>
+                <characteristic characteristicId="022912c0-2c6c-a9b1-d91f-07798ca1bd83" name="Turn Arc" value="45/1&quot;"/>
+                <characteristic characteristicId="9fa5ecaf-6733-fc53-1ba1-264a272aae04" name="Crew Type" value="Defensive"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+            <profile id="f50f-31c4-20ff-4bd4" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Adler Fore Tesla Coil (T)" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="8"/>
+                <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="6"/>
+                <characteristic characteristicId="24ec4650-4d9d-afb5-f960-3a16fed14727" name="3" value="4"/>
+                <characteristic characteristicId="3183d18a-895e-8c15-5381-c33fb31158d5" name="4" value="2"/>
+                <characteristic characteristicId="06a664bd-1a2c-bc3a-1407-d38618835877" name="Arc" value="90 Fore"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+            <profile id="2d3e-1598-727a-c872" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Adler Speerschleuder Bombs x2" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="8"/>
+                <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="-"/>
+                <characteristic characteristicId="24ec4650-4d9d-afb5-f960-3a16fed14727" name="3" value="-"/>
+                <characteristic characteristicId="3183d18a-895e-8c15-5381-c33fb31158d5" name="4" value="-"/>
+                <characteristic characteristicId="06a664bd-1a2c-bc3a-1407-d38618835877" name="Arc" value="2&quot; 360"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+            <profile id="fac9-9a5f-13a5-a22a" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Adler Heavy Speerschleuder" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="9"/>
+                <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="8"/>
+                <characteristic characteristicId="24ec4650-4d9d-afb5-f960-3a16fed14727" name="3" value="7"/>
+                <characteristic characteristicId="3183d18a-895e-8c15-5381-c33fb31158d5" name="4" value="-"/>
+                <characteristic characteristicId="06a664bd-1a2c-bc3a-1407-d38618835877" name="Arc" value="360"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
     </entry>
     <entry id="c78bdb7c-2642-7fd9-d5a5-20260f25755e" name="Arminius Class Frigate" points="0.0" categoryId="fdf35b4a-4c7e-9453-df50-c226441a6cf8" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
@@ -707,7 +829,7 @@
                 <characteristic characteristicId="b7ed9b8e-0f0f-58e5-fcf4-0a6bdc956889" name="HP" value="3"/>
                 <characteristic characteristicId="d6b8e359-4e9e-c9e0-383b-36965f458d1c" name="AP" value="3"/>
                 <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="3"/>
-                <characteristic characteristicId="6007a7be-354f-4f15-7571-114f4a501d2d" name="CC" value="1"/>
+                <characteristic characteristicId="6007a7be-354f-4f15-7571-114f4a501d2d" name="CC" value="2"/>
                 <characteristic characteristicId="c5fbe310-6d37-3ab2-33cc-5f248f3051df" name="IR" value="2"/>
                 <characteristic characteristicId="abd884ba-477b-2dff-74c2-6a907e019bdb" name="Class" value="Medium Armoured"/>
                 <characteristic characteristicId="022912c0-2c6c-a9b1-d91f-07798ca1bd83" name="Turn Arc" value="45/0&quot;"/>
@@ -1312,6 +1434,117 @@
         </link>
       </links>
     </entry>
+    <entry id="531b-d6d1-672f-1842" name="Havel Light Carrier" points="0.0" categoryId="25737efc-adbc-dc3c-7248-99ee6d9a6e72" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="40e1-9916-ceaa-3131" name="Havel" points="80.0" categoryId="(No Category)" type="unit" minSelections="1" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="0857-67a5-94b1-6147" name="Carrier (4)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="c41a-d91e-8aae-2856" name="Advanced Engines (+1&quot;)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="80ab-99fe-0944-d1e1" name="Fuel Reserves" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="d004-a58c-b87f-52cd" name="Specialised Defences (2)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="617c-170e-7f8d-42b4" name="Strategic Value (25)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="26bb-b127-691c-1346" name="Lethal Strike (Mines)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="4bb2-127c-f01a-c72f" profileTypeId="bc0a2ff0-f138-cfc5-dd1e-edb498265efb" name="Havel" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="74e0740c-a580-19f9-4d3d-a49ebaa0ef97" name="DR" value="5"/>
+                <characteristic characteristicId="6cecf2d1-c38b-7c32-980f-928bfcfd72dd" name="CR" value="6"/>
+                <characteristic characteristicId="42e40079-b4ea-86b3-13c3-781234be5776" name="MV" value="9&quot; (2&quot; min)"/>
+                <characteristic characteristicId="b7ed9b8e-0f0f-58e5-fcf4-0a6bdc956889" name="HP" value="5"/>
+                <characteristic characteristicId="d6b8e359-4e9e-c9e0-383b-36965f458d1c" name="AP" value="4"/>
+                <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="4"/>
+                <characteristic characteristicId="6007a7be-354f-4f15-7571-114f4a501d2d" name="CC" value="4"/>
+                <characteristic characteristicId="c5fbe310-6d37-3ab2-33cc-5f248f3051df" name="IR" value="3"/>
+                <characteristic characteristicId="abd884ba-477b-2dff-74c2-6a907e019bdb" name="Class" value="Medium Capital Naval"/>
+                <characteristic characteristicId="022912c0-2c6c-a9b1-d91f-07798ca1bd83" name="Turn Arc" value="Medium"/>
+                <characteristic characteristicId="9fa5ecaf-6733-fc53-1ba1-264a272aae04" name="Crew Type" value="Defensive"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+            <profile id="6f22-6f23-e3cf-d540" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Havel P/S Tesla Broadsides (S)" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="9"/>
+                <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="8"/>
+                <characteristic characteristicId="24ec4650-4d9d-afb5-f960-3a16fed14727" name="3" value="-"/>
+                <characteristic characteristicId="3183d18a-895e-8c15-5381-c33fb31158d5" name="4" value="-"/>
+                <characteristic characteristicId="06a664bd-1a2c-bc3a-1407-d38618835877" name="Arc" value="P/S Broadsides"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+            <profile id="61fa-a075-e842-c91d" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Havel Mines x2" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="(5)"/>
+                <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="-"/>
+                <characteristic characteristicId="24ec4650-4d9d-afb5-f960-3a16fed14727" name="3" value="-"/>
+                <characteristic characteristicId="3183d18a-895e-8c15-5381-c33fb31158d5" name="4" value="-"/>
+                <characteristic characteristicId="06a664bd-1a2c-bc3a-1407-d38618835877" name="Arc" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="8343-32f9-9df5-5762" targetId="9c8b55de-0a6a-1029-f939-173ba94b67bb" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="196f-2b82-d2b7-f19b" targetId="20fbf77b-d442-7168-12cb-e19c15e6580b" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="7fdc8e93-4f92-1108-3681-5923251016e8" name="Heavy Infantry Bunker" points="120.0" categoryId="5f451611-a1b8-b700-7ab9-effaa3788fc9" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="8e063a58-1420-5286-3c7a-1b49c1d54baf" name="Combat Deployment (PE, Line Infantry, 3, Standard)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
@@ -1757,7 +1990,7 @@
         </link>
       </links>
     </entry>
-    <entry id="528966c0-44f8-56d1-ffb7-b8a80c520a8d" name="Imperium Class Sky Fortress" points="145.0" categoryId="d5ba74a7-9dab-51a4-fd40-2083fe2c3f1d" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="528966c0-44f8-56d1-ffb7-b8a80c520a8d" name="Imperium Class Sky Fortress" points="150.0" categoryId="d5ba74a7-9dab-51a4-fd40-2083fe2c3f1d" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="f05fc004-0bf5-f993-68a1-f0746660d5e0" name="Area Bombardment (Tesla Bombs)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -1838,7 +2071,7 @@
           </characteristics>
           <modifiers/>
         </profile>
-        <profile id="3c35f99d-0cdc-fc2f-1d49-6414dced0ef1" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Imperium P/S Tealsa (S)" hidden="false" page="0">
+        <profile id="3c35f99d-0cdc-fc2f-1d49-6414dced0ef1" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Imperium P/S Tesla (S)" hidden="false" page="0">
           <characteristics>
             <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="9"/>
             <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="8"/>
@@ -2584,6 +2817,14 @@
           <profiles/>
           <links/>
         </entry>
+        <entry id="a242-223a-4387-575b" name="Strategic Value (50)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
       </entries>
       <entryGroups/>
       <modifiers/>
@@ -2678,7 +2919,7 @@
         </entry>
         <entry id="de83d8e6-f922-2c87-7296-bd9979d90105" name="PE Dive Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="1" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="1a44856a-f1aa-e33b-ddd3-1e074215f36b" name="Hunter (Surface+Submerged, +1)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="1a44856a-f1aa-e33b-ddd3-1e074215f36b" name="Hunter (Surface, +1)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
@@ -2886,9 +3127,9 @@
     </entry>
     <entry id="4bad96e4-38bc-c8fc-7d95-2d230362958b" name="Recke Class Assault Tank" points="0.0" categoryId="25737efc-adbc-dc3c-7248-99ee6d9a6e72" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
-        <entry id="d35e2954-edcf-bca7-0631-43290932908a" name="Recke" points="90.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="d35e2954-edcf-bca7-0631-43290932908a" name="Recke" points="100.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="0b623dad-d4b7-aabe-e3fa-a41fca428b69" name="Combat Deployment (PE, Assault Infantry, 1, Rapid)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+            <entry id="0b623dad-d4b7-aabe-e3fa-a41fca428b69" name="Combat Deployment (PE, Assault Infantry, 1, Standard)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
               <entries>
                 <entry id="11538e97-f437-e6c6-7f75-92f106dbb9cb" name="Assault Infantry" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
                   <entries>
@@ -3023,8 +3264,8 @@
             </profile>
             <profile id="9f25d5ff-d7d7-4346-fd5f-e204141f2841" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Recke P/S Teslas (S)" hidden="false" page="0">
               <characteristics>
-                <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="6"/>
-                <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="5"/>
+                <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="7"/>
+                <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="6"/>
                 <characteristic characteristicId="24ec4650-4d9d-afb5-f960-3a16fed14727" name="3" value="-"/>
                 <characteristic characteristicId="3183d18a-895e-8c15-5381-c33fb31158d5" name="4" value="-"/>
                 <characteristic characteristicId="06a664bd-1a2c-bc3a-1407-d38618835877" name="Arc" value="P/S Broadsides"/>
@@ -3035,10 +3276,10 @@
               <characteristics>
                 <characteristic characteristicId="74e0740c-a580-19f9-4d3d-a49ebaa0ef97" name="DR" value="4"/>
                 <characteristic characteristicId="6cecf2d1-c38b-7c32-980f-928bfcfd72dd" name="CR" value="7"/>
-                <characteristic characteristicId="42e40079-b4ea-86b3-13c3-781234be5776" name="MV" value="9&quot; (0&quot; min)"/>
+                <characteristic characteristicId="42e40079-b4ea-86b3-13c3-781234be5776" name="MV" value="8&quot; (0&quot; min)"/>
                 <characteristic characteristicId="b7ed9b8e-0f0f-58e5-fcf4-0a6bdc956889" name="HP" value="4"/>
                 <characteristic characteristicId="d6b8e359-4e9e-c9e0-383b-36965f458d1c" name="AP" value="4"/>
-                <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="4"/>
+                <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="3"/>
                 <characteristic characteristicId="6007a7be-354f-4f15-7571-114f4a501d2d" name="CC" value="2"/>
                 <characteristic characteristicId="c5fbe310-6d37-3ab2-33cc-5f248f3051df" name="IR" value="3"/>
                 <characteristic characteristicId="abd884ba-477b-2dff-74c2-6a907e019bdb" name="Class" value="Medium Capital Armoured"/>
@@ -3065,7 +3306,7 @@
         </link>
       </links>
     </entry>
-    <entry id="2524afb4-f575-009b-b8bc-2b7e765d47fc" name="Rhine Class Assault Carrier" points="140.0" categoryId="d5ba74a7-9dab-51a4-fd40-2083fe2c3f1d" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="2524afb4-f575-009b-b8bc-2b7e765d47fc" name="Rhine Class Assault Carrier" points="130.0" categoryId="d5ba74a7-9dab-51a4-fd40-2083fe2c3f1d" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="e01cf766-0c39-921e-5822-2580c3d4cd76" name="Carrier (6)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -3112,7 +3353,7 @@
             <characteristic characteristicId="b7ed9b8e-0f0f-58e5-fcf4-0a6bdc956889" name="HP" value="7"/>
             <characteristic characteristicId="d6b8e359-4e9e-c9e0-383b-36965f458d1c" name="AP" value="7"/>
             <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="6"/>
-            <characteristic characteristicId="6007a7be-354f-4f15-7571-114f4a501d2d" name="CC" value="5"/>
+            <characteristic characteristicId="6007a7be-354f-4f15-7571-114f4a501d2d" name="CC" value="6"/>
             <characteristic characteristicId="c5fbe310-6d37-3ab2-33cc-5f248f3051df" name="IR" value="5"/>
             <characteristic characteristicId="abd884ba-477b-2dff-74c2-6a907e019bdb" name="Class" value="Massive Capital Naval"/>
             <characteristic characteristicId="022912c0-2c6c-a9b1-d91f-07798ca1bd83" name="Turn Arc" value="Large"/>
@@ -3165,17 +3406,8 @@
     </entry>
     <entry id="b8c0392c-2dcd-fdb8-2220-7b686a4bc3a6" name="Riever Class Light Cruiser" points="0.0" categoryId="25737efc-adbc-dc3c-7248-99ee6d9a6e72" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
-        <entry id="57d0cf20-6636-b700-c077-4d4b77c605fe" name="Riever" points="50.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-          <entries>
-            <entry id="b0827cbc-c019-9d45-66ea-b03428f5d89b" name="Aggressive Crew" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
+        <entry id="57d0cf20-6636-b700-c077-4d4b77c605fe" name="Riever" points="55.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
           <entryGroups/>
           <modifiers/>
           <rules/>
@@ -3232,16 +3464,9 @@
                 <characteristic characteristicId="c5fbe310-6d37-3ab2-33cc-5f248f3051df" name="IR" value="3"/>
                 <characteristic characteristicId="abd884ba-477b-2dff-74c2-6a907e019bdb" name="Class" value="Medium Naval"/>
                 <characteristic characteristicId="022912c0-2c6c-a9b1-d91f-07798ca1bd83" name="Turn Arc" value="Medium"/>
-                <characteristic characteristicId="9fa5ecaf-6733-fc53-1ba1-264a272aae04" name="Crew Type" value="Regular"/>
+                <characteristic characteristicId="9fa5ecaf-6733-fc53-1ba1-264a272aae04" name="Crew Type" value="Aggressive"/>
               </characteristics>
-              <modifiers>
-                <modifier type="set" field="9fa5ecaf-6733-fc53-1ba1-264a272aae04" value="Aggressive" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="57d0cf20-6636-b700-c077-4d4b77c605fe" childId="b0827cbc-c019-9d45-66ea-b03428f5d89b" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
+              <modifiers/>
             </profile>
           </profiles>
           <links>
@@ -3322,7 +3547,7 @@
     </entry>
     <entry id="2ee61475-7737-a5c4-a945-834c17a27ba7" name="Saxony Class Corvette" points="0.0" categoryId="fdf35b4a-4c7e-9453-df50-c226441a6cf8" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
-        <entry id="4e17e509-316e-d7c5-1198-41a189f91ceb" name="Saxony" points="20.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="4e17e509-316e-d7c5-1198-41a189f91ceb" name="Saxony" points="25.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
             <entry id="7f584d1f-940e-28b4-240d-b33a10a620ce" name="Elusive Target" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
               <entries/>
@@ -3846,7 +4071,7 @@
     </entry>
     <entry id="54efd6f0-8a2b-bafe-36cf-e18145292cfd" name="Speerwurf Class Strike Airship" points="0.0" categoryId="fdf35b4a-4c7e-9453-df50-c226441a6cf8" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
-        <entry id="7812d98c-efee-fd5b-7149-b032b90ef6b5" name="Speerwurf" points="25.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="7812d98c-efee-fd5b-7149-b032b90ef6b5" name="Speerwurf" points="30.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
             <entry id="bd4ad498-8492-7cf7-5b22-8a01bf1a032f" name="Elusive Target" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
               <entries/>
@@ -3894,7 +4119,7 @@
                 <characteristic characteristicId="42e40079-b4ea-86b3-13c3-781234be5776" name="MV" value="12&quot; (2&quot; min)"/>
                 <characteristic characteristicId="b7ed9b8e-0f0f-58e5-fcf4-0a6bdc956889" name="HP" value="2"/>
                 <characteristic characteristicId="d6b8e359-4e9e-c9e0-383b-36965f458d1c" name="AP" value="1"/>
-                <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="1"/>
+                <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="2"/>
                 <characteristic characteristicId="6007a7be-354f-4f15-7571-114f4a501d2d" name="CC" value="2"/>
                 <characteristic characteristicId="c5fbe310-6d37-3ab2-33cc-5f248f3051df" name="IR" value="1"/>
                 <characteristic characteristicId="abd884ba-477b-2dff-74c2-6a907e019bdb" name="Class" value="Small Aerial"/>
@@ -3925,7 +4150,7 @@
               <profiles/>
               <links/>
             </entry>
-            <entry id="aa1e8ee2-0759-7864-3316-47e0401f9be6" name="Pack Tactics (Fore Cannon)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
+            <entry id="aa1e8ee2-0759-7864-3316-47e0401f9be6" name="Pack Tactics (Fore Cannon, +2)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers/>
@@ -3948,7 +4173,7 @@
           <profiles>
             <profile id="dbe79d6e-f382-225a-fc17-1aef5c33cb1f" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Stolz Fore Cannon (P)" hidden="false" page="0">
               <characteristics>
-                <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="7"/>
+                <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="6"/>
                 <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="4"/>
                 <characteristic characteristicId="24ec4650-4d9d-afb5-f960-3a16fed14727" name="3" value="3"/>
                 <characteristic characteristicId="3183d18a-895e-8c15-5381-c33fb31158d5" name="4" value="-"/>
@@ -3960,7 +4185,7 @@
               <characteristics>
                 <characteristic characteristicId="74e0740c-a580-19f9-4d3d-a49ebaa0ef97" name="DR" value="3"/>
                 <characteristic characteristicId="6cecf2d1-c38b-7c32-980f-928bfcfd72dd" name="CR" value="5"/>
-                <characteristic characteristicId="42e40079-b4ea-86b3-13c3-781234be5776" name="MV" value="11&quot; (2&quot; min)"/>
+                <characteristic characteristicId="42e40079-b4ea-86b3-13c3-781234be5776" name="MV" value="12&quot; (2&quot; min)"/>
                 <characteristic characteristicId="b7ed9b8e-0f0f-58e5-fcf4-0a6bdc956889" name="HP" value="2"/>
                 <characteristic characteristicId="d6b8e359-4e9e-c9e0-383b-36965f458d1c" name="AP" value="3"/>
                 <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="2"/>
@@ -3990,7 +4215,7 @@
         </link>
       </links>
     </entry>
-    <entry id="cf518dd7-ce73-3197-42e1-b636574030a4" name="Sturmbringer Class Submarine" points="155.0" categoryId="d5ba74a7-9dab-51a4-fd40-2083fe2c3f1d" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="cf518dd7-ce73-3197-42e1-b636574030a4" name="Sturmbringer Class Submarine" points="165.0" categoryId="d5ba74a7-9dab-51a4-fd40-2083fe2c3f1d" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="8f251607-705c-f96d-c2ae-4198784b104e" name="Evasive Manoeuver (+1)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -4024,7 +4249,7 @@
           <profiles/>
           <links/>
         </entry>
-        <entry id="8d14d082-36ce-9503-d074-4d007d1ef418" name="Strategic Value (25)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+        <entry id="8d14d082-36ce-9503-d074-4d007d1ef418" name="Strategic Value (50)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
           <entryGroups/>
           <modifiers/>
@@ -4051,8 +4276,8 @@
             <characteristic characteristicId="6cecf2d1-c38b-7c32-980f-928bfcfd72dd" name="CR" value="9"/>
             <characteristic characteristicId="42e40079-b4ea-86b3-13c3-781234be5776" name="MV" value="6&quot; (2&quot; min)"/>
             <characteristic characteristicId="b7ed9b8e-0f0f-58e5-fcf4-0a6bdc956889" name="HP" value="7"/>
-            <characteristic characteristicId="d6b8e359-4e9e-c9e0-383b-36965f458d1c" name="AP" value="6"/>
-            <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="4"/>
+            <characteristic characteristicId="d6b8e359-4e9e-c9e0-383b-36965f458d1c" name="AP" value="4"/>
+            <characteristic characteristicId="6bd13e0e-522a-f8ec-e56c-c8d22a736bfb" name="AA" value="3"/>
             <characteristic characteristicId="6007a7be-354f-4f15-7571-114f4a501d2d" name="CC" value="4"/>
             <characteristic characteristicId="c5fbe310-6d37-3ab2-33cc-5f248f3051df" name="IR" value="4"/>
             <characteristic characteristicId="abd884ba-477b-2dff-74c2-6a907e019bdb" name="Class" value="Large Capital Naval Diving"/>
@@ -4512,7 +4737,7 @@
         </link>
       </links>
     </entry>
-    <entry id="ee2075a3-4ede-e00c-eb85-d527a4490c0e" name="Valkyrie's Fury" points="125.0" categoryId="d5ba74a7-9dab-51a4-fd40-2083fe2c3f1d" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="ee2075a3-4ede-e00c-eb85-d527a4490c0e" name="Valkyrie&apos;s Fury" points="125.0" categoryId="d5ba74a7-9dab-51a4-fd40-2083fe2c3f1d" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="b21a85c5-c626-862e-13dd-ea8122ec2c25" name="PLC: SAS Fighters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -4582,7 +4807,7 @@
         </rule>
       </rules>
       <profiles>
-        <profile id="f18d4bff-a25b-d41a-e56b-69d3e6fff911" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Valkyrie's Fury Fore Cannon (P)" hidden="false" page="0">
+        <profile id="f18d4bff-a25b-d41a-e56b-69d3e6fff911" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Valkyrie&apos;s Fury Fore Cannon (P)" hidden="false" page="0">
           <characteristics>
             <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="10"/>
             <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="10"/>
@@ -4592,7 +4817,7 @@
           </characteristics>
           <modifiers/>
         </profile>
-        <profile id="2166954a-4967-8325-29ae-3d55a1829173" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Valkyrie's Fury Wing Guns (S)" hidden="false" page="0">
+        <profile id="2166954a-4967-8325-29ae-3d55a1829173" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Valkyrie&apos;s Fury Wing Guns (S)" hidden="false" page="0">
           <characteristics>
             <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="6"/>
             <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="5"/>
@@ -4602,7 +4827,7 @@
           </characteristics>
           <modifiers/>
         </profile>
-        <profile id="e8e04b49-562b-0e78-280f-92130dbc6de8" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Valkyrie's Fury Aft Guns (S)" hidden="false" page="0">
+        <profile id="e8e04b49-562b-0e78-280f-92130dbc6de8" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Valkyrie&apos;s Fury Aft Guns (S)" hidden="false" page="0">
           <characteristics>
             <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="6"/>
             <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="5"/>
@@ -4612,7 +4837,7 @@
           </characteristics>
           <modifiers/>
         </profile>
-        <profile id="17c6afb6-71b1-0662-4f4b-23c12dcf11c2" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Valkyrie's Fury Bombs x3" hidden="false" page="0">
+        <profile id="17c6afb6-71b1-0662-4f4b-23c12dcf11c2" profileTypeId="28d3b074-45c4-5c92-58a6-b92f6b242b4f" name="Valkyrie&apos;s Fury Bombs x3" hidden="false" page="0">
           <characteristics>
             <characteristic characteristicId="f3391043-6ab5-a123-0426-00755af327cc" name="1" value="5"/>
             <characteristic characteristicId="347da438-725c-e23c-b02d-7cd0d4d32324" name="2" value="-"/>
@@ -4622,7 +4847,7 @@
           </characteristics>
           <modifiers/>
         </profile>
-        <profile id="3fbf4f9b-2f8d-350c-78df-0fc94e9ccf3d" profileTypeId="bc0a2ff0-f138-cfc5-dd1e-edb498265efb" name="Valkyrie's Fury" hidden="false" page="0">
+        <profile id="3fbf4f9b-2f8d-350c-78df-0fc94e9ccf3d" profileTypeId="bc0a2ff0-f138-cfc5-dd1e-edb498265efb" name="Valkyrie&apos;s Fury" hidden="false" page="0">
           <characteristics>
             <characteristic characteristicId="74e0740c-a580-19f9-4d3d-a49ebaa0ef97" name="DR" value="5"/>
             <characteristic characteristicId="6cecf2d1-c38b-7c32-980f-928bfcfd72dd" name="CR" value="7"/>
@@ -4818,15 +5043,15 @@ Each Game Turn a Prussian Empire player can have their Commodore perform ONE of 
 
 * Pass the Tools - One Model within 8” of the Commodore’s Model may re-roll a single failed Repair attempt.
 
-* Stand up and be Counted! - A Squadron within 8"of the Commodore’s Model may re-roll a single failed Disorder Test.
+* Stand up and be Counted! - A Squadron within 8&quot;of the Commodore’s Model may re-roll a single failed Disorder Test.
 
 Commodore Doctrines
 
 In addition to their Command Abilities, all Prussian Empire Commodores can perform ONE of the following Doctrine Abilities ONCE per Game Turn. These Abilities are designed to reflect the various combat doctrines prevalent in the Prussian Empire.
 
-* Over-Charge the Coils! - This Ability may be activated during the Command Segment of a non-Disordered Squadron's Activation provided a member of the Squadron is within 8” of the Commodore’s Model. The Squadron may elect to re-roll ALL of the INITIAL Attack Dice from an Attack using Tesla Weaponry. Only INITIAL Dice are re-rolled and the second result MUST be accepted.
+* Over-Charge the Coils! - This Ability may be activated during the Command Segment of a non-Disordered Squadron&apos;s Activation provided a member of the Squadron is within 8” of the Commodore’s Model. The Squadron may elect to re-roll ALL of the INITIAL Attack Dice from an Attack using Tesla Weaponry. Only INITIAL Dice are re-rolled and the second result MUST be accepted.
 
-* Unleash the Imperial Guard! - This Ability may be activated during the Command Segment of a Commodore's Activation. For the remainder of the Activation, the Commodore's Model gains the Terror Tactics (3) Model Assigned Rule.</description>
+* Unleash the Imperial Guard! - This Ability may be activated during the Command Segment of a Commodore&apos;s Activation. For the remainder of the Activation, the Commodore&apos;s Model gains the Terror Tactics (3) Model Assigned Rule.</description>
           <modifiers/>
         </rule>
       </rules>


### PR DESCRIPTION
Naval Forces
Sturmbringer
Points cost increased to 165 from 155.
AA decreased from 4 to 3.
Strategic value increased to 50 from 25.
AP decreased to 4 from 6.
Rhine
Points cost decreased to 130 from 140.
CC increased to 6 from 5.
New: Havel Light Carrier
Riever
Points cost increased to 55 from 50
Crew type changed to Aggressive
Naturally, may no longer upgrade crew to Aggressive from Regular for +5 points
Stolz
Movement increased to 12" from 11"
Fore guns RB1 AD decreased to 6 from 7
Pack Tactics (Fore Cannon) changed to Pack Tactics (Fore Cannon, +2)
Saxony
Points cost increased to 25 from 20
Aerial Forces
Imperium
Points cost increased to 150 from 145
New: Adler Heavy Bomber
Speerwurf
Points cost increased to 30 from 25
AA increased to 2 from 1
SAW Dive Bombers
Hunter (Surface & Submerged, +1) changed to Hunter (Surface, +1)
Armoured Forces
Metzger
Added Strategic Value (50)
Recke
Points value increased to 100 from 90
Movement decreased to 8" from 9"
AA decreased to 3 from 4
Combat Deployment (Assault Infantry,1, Rapid) changed to Combat Deployment (Assault Infantry,1, Standard)
P/S Tesla Coils AD changed to 7/6/-/- from 6/5/-/-
CF-4
CC increased to 2 from 1
Infantry Formations
Assault Infantry
AP reduced to 3 from 4